### PR TITLE
📖  Fix event listeners documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,13 @@ As it can be seen in the result, `AnimatedDataset` supports _path morphing_ and 
 />
 ```
 
-It also accepts events listener. They can be in kebab-case (`on-mouseover`) or camel case (`onMouseOver`).
+<h3 id="events">
+  <a  href="#events">#</a> events
+</h3>
+
+- Type: `{ [key: string]: (mouseEvent: MouseEvent, datum: any) => void }`
+
+Event listeners keys can be written in kebab-case (`on-mouseover`) or camel case (`onMouseOver`).
 
 ```jsx
 <AnimatedDataset

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ It also accepts events listener. They can be in kebab-case (`on-mouseover`) or c
 
 ```jsx
 <AnimatedDataset
-  attrs = {{
+  events={{
     'on-click': datum => console.log(datum),
     onMouseOver: (datum, index, nodes) => ...
   }}

--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ It also accepts events listener. They can be in kebab-case (`on-mouseover`) or c
 ```jsx
 <AnimatedDataset
   events={{
-    'on-click': datum => console.log(datum),
-    onMouseOver: (datum, index, nodes) => ...
+    'on-click': (mouseEvent, datum) => console.log(datum),
+    onMouseOver: (mouseEvent, datum) => ...
   }}
 />
 ```


### PR DESCRIPTION
As stated in #6, event listeners do not work if they're specified in the `attrs` object, as they're triggered as soon as the component is rendered; the correct prop name is `events`.

The parameters list for the event listeners was also fixed.